### PR TITLE
gulp-plumber eklendi

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ const sass = require('gulp-sass')
 const nodemon = require('gulp-nodemon')
 const prefix = require('gulp-autoprefixer')
 const sourcemaps = require('gulp-sourcemaps')
+const plumber = require('gulp-plumber')
 const reload = browserSync.reload
 
 gulp.task('browser-sync', function () {
@@ -19,6 +20,7 @@ gulp.task('browser-sync', function () {
 
 gulp.task('css', () => {
   return gulp.src('./scss/main.scss')
+  .pipe(plumber([{errorHandler: false}]))
   .pipe(sass())
   .pipe(prefix())
   .pipe(gulp.dest('./'))

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "main": "gulpfile.js",
   "dependencies": {},
   "devDependencies": {
-    "express": "^4.16.2",
-    "gulp-nodemon": "^2.2.1",
-    "gulp": "^3.9.1",
     "browser-sync": "^2.18.13",
-    "gulp-sass": "^3.1.0",
+    "express": "^4.16.2",
+    "gulp": "^3.9.1",
     "gulp-autoprefixer": "^4.0.0",
+    "gulp-nodemon": "^2.2.1",
+    "gulp-plumber": "^1.1.0",
+    "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^2.6.1"
   },
   "scripts": {


### PR DESCRIPTION
SCSS yazarken syntax hatası yaptığımızda browser-sync duruyordu ve gulp komutunu tekrar çalıştırmamız gerekiyordu. gulp-plumber ile syntax hatası konsola basılıyor ve düzeltildiğinde browser-sync çalışmaya devam ediyor.